### PR TITLE
feat(import-flow):Auto detect Build tool

### DIFF
--- a/frontend/public/extend/devconsole/components/ImportFlowForm/ImportFlowForm.scss
+++ b/frontend/public/extend/devconsole/components/ImportFlowForm/ImportFlowForm.scss
@@ -1,17 +1,10 @@
 .odc-import-form {
-  &__url-input {
-    position: relative;
-  }
   &__success-icon {
-    position: absolute;
-    right: -25px;
-    bottom: 31px;
-    color: green;
-    font-size: 20px;
+    color: var(--pf-global--success-color--200);
+    font-size: 15px;
+    margin-left: 5px;
   }
   &__loader {
-    position: absolute;
-    bottom: 33px;
-    right: -25px;
+    margin-left: 5px;
   }
 }

--- a/frontend/public/extend/devconsole/components/ImportFlowForm/ImportFlowForm.scss
+++ b/frontend/public/extend/devconsole/components/ImportFlowForm/ImportFlowForm.scss
@@ -1,10 +1,17 @@
 .odc-import-form {
+  &__url-input {
+    position: relative;
+  }
   &__success-icon {
-    color: #1e4f18;
-    font-size: 12px;
-    margin-left: 5px;
+    position: absolute;
+    right: -25px;
+    bottom: 31px;
+    color: green;
+    font-size: 20px;
   }
   &__loader {
-    margin-left: 5px;
+    position: absolute;
+    bottom: 33px;
+    right: -25px;
   }
 }

--- a/frontend/public/extend/devconsole/components/ImportFlowForm/ImportFlowForm.tsx
+++ b/frontend/public/extend/devconsole/components/ImportFlowForm/ImportFlowForm.tsx
@@ -77,10 +77,13 @@ export class ImportFlowForm extends React.Component<Props, State> {
   }
   private randomString = this.generateRandomString();
   private poller;
+<<<<<<< HEAD
   private imageStreams: { [name: string]: string[] } = {
     '': ['Select builder image', ''],
   };
 
+=======
+>>>>>>> feat(import-flow):read git url status from GS_CR
   private onBrowserClose = event => {
     event.preventDefault();
     if (this.state.gitSourceCreated && !this.state.componentCreated) {
@@ -187,7 +190,11 @@ export class ImportFlowForm extends React.Component<Props, State> {
             }`,
             lastEnteredGitUrl: this.state.gitRepoUrl,
           });
+<<<<<<< HEAD
           this.poller=setInterval(this.checkUrlValidationStatus, 3000);
+=======
+          this.poller=setInterval(this.checkUrlValidationStatus.bind(this), 3000);
+>>>>>>> feat(import-flow):read git url status from GS_CR
 
         },
       );
@@ -279,7 +286,11 @@ export class ImportFlowForm extends React.Component<Props, State> {
     history.goBack();
   }
 
+<<<<<<< HEAD
   checkUrlValidationStatus = () => {
+=======
+  checkUrlValidationStatus() {
+>>>>>>> feat(import-flow):read git url status from GS_CR
     GitSourceModel.path='gitsources';
     k8sGet(GitSourceModel, this.state.gitSourceName, this.props.activeNamespace).then((res) => {
       if (res.status.connection.state === 'ok') {
@@ -291,7 +302,11 @@ export class ImportFlowForm extends React.Component<Props, State> {
     });
   }
 
+<<<<<<< HEAD
   autocompleteFilter = (text, item) => fuzzy(text, item[0]);
+=======
+  autocompleteFilter = (text, item) => fuzzy(text, item);
+>>>>>>> feat(import-flow):read git url status from GS_CR
 
   render() {
     const {
@@ -306,6 +321,7 @@ export class ImportFlowForm extends React.Component<Props, State> {
       nameError,
       builderImageError,
     } = this.state;
+<<<<<<< HEAD
 
     const builderImages = _.filter(this.props.resources.imagestreams.data, imagestream => {
       return isBuilder(imagestream);
@@ -317,6 +333,8 @@ export class ImportFlowForm extends React.Component<Props, State> {
       });
     });
 
+=======
+>>>>>>> feat(import-flow):read git url status from GS_CR
     let gitTypeField, showGitValidationStatus;
     if (gitType || gitTypeError) {
       gitTypeField = <FormGroup controlId="import-git-type" className={gitTypeError ? 'has-error' : ''}>
@@ -343,7 +361,7 @@ export class ImportFlowForm extends React.Component<Props, State> {
         data-test-id="import-form"
         onSubmit={this.handleSubmit}
         className="co-m-pane__body-group co-m-pane__form">
-        <FormGroup controlId="import-git-repo-url" className={gitRepoUrlError ? 'has-error' : ''}>
+        <FormGroup controlId="import-git-repo-url" className={gitRepoUrlError ? 'has-error odc-import-form__url-input' : 'odc-import-form__url-input'}>
           <ControlLabel className="co-required">Git Repository URL</ControlLabel>
           {showGitValidationStatus}
           <FormControl
@@ -356,6 +374,7 @@ export class ImportFlowForm extends React.Component<Props, State> {
             data-test-id="import-git-repo-url"
             autoComplete="off"
             name="gitRepoUrl" />
+          {showGitValidationStatus}
           <HelpBlock>{ gitRepoUrlError ? gitRepoUrlError : 'Some helper text' }</HelpBlock>
         </FormGroup>
         { gitTypeField }

--- a/frontend/public/extend/devconsole/models/index.ts
+++ b/frontend/public/extend/devconsole/models/index.ts
@@ -26,3 +26,16 @@ export const GitSourceComponentModel: K8sKind = {
   namespaced: true,
   kind: 'Component',
 };
+
+export const GitSourceAnalysisModel: K8sKind = {
+  label: 'GitSourceAnalysis',
+  labelPlural: 'GitSourceAnalyses',
+  apiGroup: 'devconsole.openshift.io',
+  crd: true,
+  apiVersion: 'v1alpha1',
+  path: 'gitsourceanalysis',
+  plural: 'gitsourceanalyses',
+  abbr: 'GSA',
+  namespaced: true,
+  kind: 'GitSourceAnalysis',
+};


### PR DESCRIPTION
This PR includes:
- Detects the Build tool for the user, when valid git url is entered. A loader shows up immediately after the git url validation is positive
- Allows the user to select a build tool when the detected build type is not listed in the Builder Image    drop-down
- User doesnot have to wait for auto-detection of build tool to complete, instead can select one from the Builder Image drop-down and move to the next page
- User's manual selection is not overridden by detected build tool

Refer Jira Story: https://jira.coreos.com/browse/ODC-209
Watch Video here: https://youtu.be/W5Nv4uO-7vU